### PR TITLE
Fix upload multiple files with uploadUrl

### DIFF
--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -105,7 +105,7 @@ class FileInput extends InputWidget
         /**
          * Auto-set multiple file upload naming convention
          */
-        if (ArrayHelper::getValue($this->options, 'multiple')) {
+        if (ArrayHelper::getValue($this->options, 'multiple') && !ArrayHelper::getValue($this->pluginOptions, 'uploadUrl')) { 
             $hasModel = $this->hasModel();
             if ($hasModel && strpos($this->attribute, '[]') === false) {
                 $this->attribute .= '[]';


### PR DESCRIPTION
## Scope
This pull request includes a

- [X ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
When 'multiple' => true and set uploadUrl, then UploadedFile return empty result. 
So it check is set "ajaxUpload" and don't append brackets "[ ]" if "multiple" is set to true

## Related Issues
If this is related to an existing ticket, include a link to it as well.