### PR TITLE
Support translations for language codes with hyphen

### DIFF
--- a/src/FileInput.php
+++ b/src/FileInput.php
@@ -91,7 +91,7 @@ class FileInput extends InputWidget
     {
         $this->_msgCat = 'fileinput';
         $this->initI18N(__DIR__);
-        $this->initLanguage();
+        $this->initLanguage('language',true);
         $this->registerAssets();
         if ($this->pluginLoading) {
             Html::addCssClass($this->options, 'file-loading');


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
Although bootstrap-fileinput has support for languages with '-' (like 'pt-BR','zh-TW' ) the function initLanguage() is setting just the part before '-' ('pt','zh'), that makes languages as brazilian portuguese being changed for european portuguese, adding the parameter $full = true makes it consider the correct idiom

## Related Issues
#150 